### PR TITLE
Fix: Bump dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.13"
 dependencies = [
     "cryptography==46.0.7",
     "pyasn1==0.6.3",
-    "pyasn1-alt-modules==0.4.9",
+    "pyasn1-alt-modules==0.4.10",
     "robotframework==7.4.2",
     "pkilint==0.13.2",
     "robotframework-requests==0.9.7",
@@ -28,7 +28,7 @@ dev = [
     "safety>=3.7.0,<4.0.0",
     "pylint>=4.0.4,<5.0.0",
     "ruff>=0.15.9,<1.0.0",
-    "robotframework-robocop==8.2.5",
+    "robotframework-robocop==8.2.6",
     "pyright[nodejs]==1.1.408",
     "codespell==2.4.2",
     "reuse==6.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 dev = [
     "safety>=3.7.0,<4.0.0",
     "pylint>=4.0.4,<5.0.0",
-    "ruff>=0.15.9,<1.0.0",
+    "ruff>=0.15.10,<1.0.0",
     "robotframework-robocop==8.2.6",
     "pyright[nodejs]==1.1.408",
     "codespell==2.4.2",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright 2024 Siemens AG

SPDX-License-Identifier: Apache-2.0
-->

Update dependencies.

## Description
Updated the following dependencies:
- `ruff` to version 0.15.10
- `pyasn1-alt-modules` to version 0.4.10
- `robotframework-robocop` to version 8.2.6

## Motivation and Context

- Fix invalid `CertStatus` structure.


## How Has This Been Tested?

- unit tests